### PR TITLE
Add loader icon to docs and demo

### DIFF
--- a/src/data/icons.yaml
+++ b/src/data/icons.yaml
@@ -73,3 +73,4 @@
 - page-layout
 - lock
 - location
+- loader

--- a/src/pages/demos/availability-control.hbs
+++ b/src/pages/demos/availability-control.hbs
@@ -6,7 +6,6 @@
         <div class="Panel-cell">
           <a href="">Player Name</a>
         </div>
-        {{#iterate 2}}
           <div class="Panel-cell u-textCenter">
           <div class="Popup">
             <button class="Button Button--smallSquare Popup-toggle js-popupToggle">
@@ -28,27 +27,32 @@
             </div>
           </div>
         </div>
-        {{/iterate}}
         {{#iterate 2}}
           <div class="Panel-cell u-textCenter">
           <div class="Popup">
             <button class="Button Button--smallSquare Button--yes Popup-toggle js-popupToggle">
-              {{svg "check" class="Icon" role="presentation"}}
+              {{#compare @count "==" 2}}
+                {{svg "loader" class="Icon Icon--loader" role="presentation"}}
+              {{else}}
+                {{svg "check" class="Icon" role="presentation"}}
+              {{/compare}}
             </button>
-            <div class="Popup-container js-popupContainer" style="width: auto">
+            <div class="Popup-container js-popupContainer" style="width: 300px">
               <div class="Popup-content u-padSm u-flex u-flexAlignItemsCenter">
-                <div class="ButtonGroup js-ButtonGroupDemo u-sizeFill" style="width: 225px">
-                  <button class="Button u-padSidesXs  Button--yes  u-size1of3">
+                <div class="ButtonGroup js-ButtonGroupDemo u-sizeFill">
+                  <button class="Button u-padSidesXs  Button--yes  u-size1of4">
                     Going
                   </button>
-                  <button class="Button u-padSidesXs  Button--maybe u-size1of3">
+                  <button class="Button u-padSidesXs  Button--maybe u-size1of4">
                     Maybe
                   </button>
-                  <button class="Button u-padSidesXs  Button--no u-size1of3">
+                  <button class="Button u-padSidesXs  Button--no u-size1of4">
                     No
                   </button>
+                  <button class="Button u-padSidesXs u-size1of4">
+                    Clear
+                  </button>
                 </div>
-                <a href="" class="u-textBold u-padSidesSm u-spaceLeftSm u-textNoWrap">Reset</a>
               </div>
             </div>
           </div>
@@ -58,7 +62,11 @@
           <div class="Panel-cell u-textCenter">
           <div class="Popup">
             <button class="Button Button--smallSquare Button--maybe Popup-toggle js-popupToggle">
-              <span class="u-textBold">?</span>
+              {{#compare @count "==" 2}}
+                {{svg "loader" class="Icon Icon--loader" role="presentation"}}
+              {{else}}
+                <span class="u-textBold">?</span>
+              {{/compare}}
             </button>
             <div class="Popup-container js-popupContainer">
               <div class="Popup-content u-padSm">
@@ -83,7 +91,7 @@
             <button class="Button Button--smallSquare Button--no Popup-toggle js-popupToggle">
               {{svg "dismiss" class="Icon" role="presentation"}}
             </button>
-            <div class="Popup-container Popup-container--rightHang js-popupContainer">
+            <div class="Popup-container js-popupContainer">
               <div class="Popup-content u-padSm">
                 <div class="ButtonGroup js-ButtonGroupDemo" >
                   <button class="Button u-padSidesXs  Button--yes u-size1of3">
@@ -100,92 +108,15 @@
             </div>
           </div>
         </div>
-      </div>
-      <div class="Panel-row Panel-row--withCells u-flexAlignItemsCenter">
-        <div class="Panel-cell">
-          <a href="">Player Name</a>
-        </div>
-        {{#iterate 2}}
-          <div class="Panel-cell u-textCenter">
-          <div class="Popup">
-            <button class="Button Button--smallSquare Popup-toggle js-popupToggle">
-            </button>
-            <div class="Popup-container js-popupContainer">
-              <div class="Popup-content u-padSm">
-                <div class="ButtonGroup js-ButtonGroupDemo" >
-                  <button class="Button u-padSidesXs  Button--yes u-size1of3">
-                    Going
-                  </button>
-                  <button class="Button u-padSidesXs  Button--maybe u-size1of3">
-                    Maybe
-                  </button>
-                  <button class="Button u-padSidesXs  Button--no u-size1of3">
-                    No
-                  </button>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        {{/iterate}}
-        {{#iterate 2}}
-          <div class="Panel-cell u-textCenter">
-          <div class="Popup">
-            <button class="Button Button--smallSquare Button--yes Popup-toggle js-popupToggle">
-              {{svg "check" class="Icon" role="presentation"}}
-            </button>
-            <div class="Popup-container js-popupContainer" style="width: auto">
-              <div class="Popup-content u-padSm u-flex u-flexAlignItemsCenter">
-                <div class="ButtonGroup js-ButtonGroupDemo u-sizeFill" style="width: 225px">
-                  <button class="Button u-padSidesXs  Button--yes  u-size1of3">
-                    Going
-                  </button>
-                  <button class="Button u-padSidesXs  Button--maybe u-size1of3">
-                    Maybe
-                  </button>
-                  <button class="Button u-padSidesXs  Button--no u-size1of3">
-                    No
-                  </button>
-                </div>
-                <a href="" class="u-textBold u-padSidesSm u-spaceLeftSm u-textNoWrap">Reset</a>
-              </div>
-            </div>
-          </div>
-        </div>
-        {{/iterate}}
-        {{#iterate 2}}
-          <div class="Panel-cell u-textCenter">
-          <div class="Popup">
-            <button class="Button Button--smallSquare Button--maybe Popup-toggle js-popupToggle">
-              <span class="u-textBold">?</span>
-            </button>
-            <div class="Popup-container js-popupContainer">
-              <div class="Popup-content u-padSm">
-                <div class="ButtonGroup js-ButtonGroupDemo" >
-                  <button class="Button u-padSidesXs  Button--yes u-size1of3">
-                    Going
-                  </button>
-                  <button class="Button u-padSidesXs   Button--maybe  u-size1of3">
-                    Maybe
-                  </button>
-                  <button class="Button u-padSidesXs   Button--no u-size1of3">
-                    No
-                  </button>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        {{/iterate}}
         <div class="Panel-cell u-textCenter">
           <div class="Popup">
-            <button class="Button Button--smallSquare Button--yes Popup-toggle js-popupToggle">
-              {{svg "check" class="Icon" role="presentation"}}
+            <button class="Button Button--smallSquare Button--no Popup-toggle js-popupToggle">
+              {{svg "loader" class="Icon Icon--loader" role="presentation"}}
             </button>
             <div class="Popup-container Popup-container--rightHang js-popupContainer">
               <div class="Popup-content u-padSm">
                 <div class="ButtonGroup js-ButtonGroupDemo" >
-                  <button class="Button u-padSidesXs  Button--yes  u-size1of3">
+                  <button class="Button u-padSidesXs  Button--yes u-size1of3">
                     Going
                   </button>
                   <button class="Button u-padSidesXs   Button--maybe u-size1of3">
@@ -202,6 +133,4 @@
       </div>
     </div>
   </div>
-
-
 </div>

--- a/src/pages/icons.hbs
+++ b/src/pages/icons.hbs
@@ -12,7 +12,11 @@ notes: |
   {{#each (data "icons")}}
     <li class="Grid-cell align-center u-size6of24 u-spaceTopMd">
       <div class="u-padLg" data-bg="fill">
-        <h1>{{svg this class="Icon"}}</h1>
+        {{#compare this "==" "loader"}}
+          <h1>{{svg this class="Icon Icon--loader"}}</h1>
+        {{else}}
+          <h1>{{svg this class="Icon"}}</h1>
+        {{/compare}}
         <p>{{this}}</p>
       </div>
     </li>

--- a/src/patterns/components/icon/loader.hbs
+++ b/src/patterns/components/icon/loader.hbs
@@ -1,0 +1,18 @@
+---
+notes: |
+  Add modifier `Icon--loader` to the "loader" icon for an animated SVG icon that inherits parent text color and size.
+---
+
+<button class="Button Button--smallSquare Button--primary">
+  {{svg "loader" class="Icon Icon--loader" role="presentation"}}
+</button>
+
+<h1>
+  {{svg "loader" class="Icon Icon--loader" role="presentation"}}
+  Heading element with loading icon
+</h1>
+
+<button class="Button Button--large">
+  {{svg "loader" class="Icon Icon--loader u-spaceRightSm" role="presentation"}}
+  Loading
+</button>

--- a/src/patterns/components/loader/loader-icon.hbs
+++ b/src/patterns/components/loader/loader-icon.hbs
@@ -1,0 +1,18 @@
+---
+notes: |
+  In cases where a loader needs to display inline, or act similarly to an icon (inheriting parent color and size), there is an SVG loader icon that works with the `.Icon` styles. Simply add the `Icon--loader` modifier to apply the animation.
+---
+
+<button class="Button Button--smallSquare Button--primary">
+  {{svg "loader" class="Icon Icon--loader" role="presentation"}}
+</button>
+
+<h1>
+  {{svg "loader" class="Icon Icon--loader" role="presentation"}}
+  Heading element with loading icon
+</h1>
+
+<button class="Button Button--large">
+  {{svg "loader" class="Icon Icon--loader u-spaceRightSm" role="presentation"}}
+  Loading
+</button>


### PR DESCRIPTION
Adds loader icon to:
- icon data file
- Icon demo page
- Loader docs
- Icon docs
- Availability demo

Corresponding TS-UI PR: https://github.com/teamsnap/teamsnap-ui/pull/73

## Icons page
![loader-icon-2](https://user-images.githubusercontent.com/9888467/38519583-ef1e78ee-3c05-11e8-8708-f0e44b0d9bd6.gif)

## Icon pattern
![loader-icon-3](https://user-images.githubusercontent.com/9888467/38519584-ef4a7d2c-3c05-11e8-9213-4ebef88a593f.gif)

## Loader pattern
![loader-icons](https://user-images.githubusercontent.com/9888467/38519586-ef6fb358-3c05-11e8-9c98-2ffa316507b3.gif)
