### PR TITLE
Add theme switcher

### DIFF
--- a/config.js
+++ b/config.js
@@ -2,7 +2,10 @@
 
 module.exports = {
   'ui': {
-    src: './src/teamsnap-ui/src/css/teamsnap-ui.scss',
+    src: [
+      './src/teamsnap-ui/src/css/teamsnap-ui.scss',
+      './src/teamsnap-ui/src/css/themes/*.scss'
+    ],
     dest: './dist/assets/toolkit/styles',
     name: 'ui'
   },

--- a/src/assets/drizzle/scripts/drizzle.js
+++ b/src/assets/drizzle/scripts/drizzle.js
@@ -59,3 +59,83 @@ u('.js-drizzleClassicCssToggle').on('click', () => {
     style.attr('disabled', 'disabled');
   }
 });
+
+// Theme switching
+// From A List Apart article: http://alistapart.com/article/alternate
+// (http://alistapart.com/d/alternate/styleswitcher.js)
+
+document.getElementById('js-themeSelect').addEventListener('change', function() {
+  var themeSelect = this;
+  var theme = themeSelect.value;
+
+  setActiveStyleSheet(theme);
+  return false;
+})
+
+function setActiveStyleSheet(title) {
+  var i, a, main;
+  for(i=0; (a = document.getElementsByTagName("link")[i]); i++) {
+    if(a.getAttribute("rel").indexOf("style") != -1 && a.getAttribute("title")) {
+      a.disabled = true;
+      if(a.getAttribute("title") == title) a.disabled = false;
+    }
+  }
+}
+
+function getActiveStyleSheet() {
+  var i, a;
+  for(i=0; (a = document.getElementsByTagName("link")[i]); i++) {
+    if(a.getAttribute("rel").indexOf("style") != -1 && a.getAttribute("title") && !a.disabled) return a.getAttribute("title");
+  }
+  return null;
+}
+
+function getPreferredStyleSheet() {
+  var i, a;
+  for(i=0; (a = document.getElementsByTagName("link")[i]); i++) {
+    if(a.getAttribute("rel").indexOf("style") != -1
+       && a.getAttribute("rel").indexOf("alt") == -1
+       && a.getAttribute("title")
+       ) return a.getAttribute("title");
+  }
+  return null;
+}
+
+function createCookie(name,value,days) {
+  if (days) {
+    var date = new Date();
+    date.setTime(date.getTime()+(days*24*60*60*1000));
+    var expires = "; expires="+date.toGMTString();
+  }
+  else expires = "";
+  document.cookie = name+"="+value+expires+"; path=/";
+}
+
+function readCookie(name) {
+  var nameEQ = name + "=";
+  var ca = document.cookie.split(';');
+  for(var i=0;i < ca.length;i++) {
+    var c = ca[i];
+    while (c.charAt(0)==' ') c = c.substring(1,c.length);
+    if (c.indexOf(nameEQ) == 0) return c.substring(nameEQ.length,c.length);
+  }
+  return null;
+}
+
+window.onload = function(e) {
+  var cookie = readCookie("style");
+  var title = cookie ? cookie : getPreferredStyleSheet();
+  setActiveStyleSheet(title);
+
+  var themeSelector = document.getElementById('js-themeSelect');
+  themeSelector.value = title;
+}
+
+window.onunload = function(e) {
+  var title = getActiveStyleSheet();
+  createCookie("style", title, 365);
+}
+
+var cookie = readCookie("style");
+var title = cookie ? cookie : getPreferredStyleSheet();
+setActiveStyleSheet(title);

--- a/src/data/themes.yaml
+++ b/src/data/themes.yaml
@@ -1,0 +1,71 @@
+- theme: blue-steel
+  name: Blue Steel
+
+- theme: care-bear
+  name: Care Bear
+
+- theme: christmas-sweater
+  name: Christmas Sweater
+
+- theme: custom-aquablue
+  name: Aquablue
+
+- theme: custom-black
+  name: Black
+
+- theme: custom-blue
+  name: Blue
+
+- theme: custom-darkblue
+  name: Dark Blue
+
+- theme: custom-darkgreen
+  name: Dark Green
+
+- theme: custom-darkred
+  name: Dark Red
+
+- theme: custom-goldenyellow
+  name: Golden Yellow
+
+- theme: custom-gray
+  name: Gray
+
+- theme: custom-green
+  name: Green
+
+- theme: custom-leafgreen
+  name: Leaf Green
+
+- theme: custom-lemonyellow
+  name: Lemon Yellow
+
+- theme: custom-lightblue
+  name: Light Blue
+
+- theme: custom-orange
+  name: Orange
+
+- theme: custom-pink
+  name: Pink
+
+- theme: custom-purple
+  name: Purple
+
+- theme: custom-red
+  name: Red
+
+- theme: league
+  name: League
+
+- theme: maple-leaf
+  name: Maple Leaf
+
+- theme: portland-oregon
+  name: Portland Oregon
+
+- theme: ranger-smith
+  name: Ranger Smith
+
+- theme: up-beet
+  name: Up Beet

--- a/src/patterns/components/button/primary.hbs
+++ b/src/patterns/components/button/primary.hbs
@@ -1,3 +1,7 @@
+---
+order: 2
+---
+
 <button class="Button Button--primary">
   Primary Button
 </button>

--- a/src/templates/blank.hbs
+++ b/src/templates/blank.hbs
@@ -13,7 +13,10 @@
       {{/if}}
       <link rel="stylesheet" href="{{@root.baseurl}}/assets/drizzle/styles/drizzle.css">
       <link rel="stylesheet" href="https://aa5498032991a101442c-34c0f4eec246050dfc1ee92670a7b97d.ssl.cf1.rackcdn.com/app-team-d0447b9a4fe8ca56541b435630b6aeca.css">
-      <link rel="stylesheet" href="{{@root.baseurl}}/assets/toolkit/styles/teamsnap-ui.css">
+      <link rel="stylesheet" href="{{@root.baseurl}}/assets/toolkit/styles/teamsnap-ui.css" title="teamsnap-ui" class="cssTheme">
+      {{#each (data "themes")}}
+        <link rel="alternate stylesheet" title="{{theme}}" href="{{@root.baseurl}}/assets/toolkit/styles/{{theme}}.css" class="cssTheme">
+      {{/each}}
       {{#each styles}}
         <link rel="stylesheet" href="{{@root.baseurl}}/assets/toolkit/styles/{{this}}.css">
       {{/each}}

--- a/src/templates/drizzle/nav.hbs
+++ b/src/templates/drizzle/nav.hbs
@@ -28,6 +28,20 @@
 
     {{> drizzle.classic-css-toggle}}
 
+    <div class="drizzle-Nav-item drizzle-u-marginTop">
+      <div class="FieldGroup">
+        <label class="FieldGroup-label" for="select-1">Select a theme</label>
+        <div class="SelectBox">
+          <select class="SelectBox-options js-themeSelect" id="js-themeSelect" name="js-themeSelect">
+            <option value="teamsnap-ui">Default</option>
+            {{#each (data "themes")}}
+              <option value={{theme}}>{{name}}</option>
+            {{/each}}
+          </select>
+        </div>
+      </div>
+    </div>
+
     {{!-- Top-level pages --}}
     <h3 class="drizzle-Nav-item">Intro</h3>
     <ul class="drizzle-Nav-menu">


### PR DESCRIPTION
Add theme switcher for better theme design and management in TS-UI. Changing the theme also sets a cookie so that pages retain theme choice on reload (selecting different patterns, for example), and on a new visit to the pattern library.

![theme-switcher](https://user-images.githubusercontent.com/9888467/38682201-1fa48108-3e30-11e8-9c3d-f3aff8b0b2df.gif)
