### PR TITLE
Large style updates

### DIFF
--- a/src/patterns/components/Input/large.hbs
+++ b/src/patterns/components/Input/large.hbs
@@ -1,0 +1,7 @@
+---
+order: 3
+notes: |
+  `.Input--large` modifier creates a taller input with a larger font-size that corresponds with other large elements (button, select). Good for mobile screens since it has a 16px font size and won't cause the screen to zoom.
+---
+
+<input class="Input Input--large" type="text" placeholder="Large Input">

--- a/src/patterns/components/select-box/large.hbs
+++ b/src/patterns/components/select-box/large.hbs
@@ -1,0 +1,9 @@
+<div class="SelectBox SelectBox--large">
+  <select class="SelectBox-options" name="select-2" id="select-2">
+    <option value="">Option 1</option>
+    <option value="">Option 2</option>
+    <option value="">Option 3</option>
+    <option value="">Option 4</option>
+    <option value="">Option 5</option>
+  </select>
+</div>

--- a/src/patterns/components/table/scrollable-body.hbs
+++ b/src/patterns/components/table/scrollable-body.hbs
@@ -1,0 +1,184 @@
+---
+order: 5
+notes: |
+  Body of table scrolls with fixed header row.
+---
+
+
+<div class="Panel Panel--striped">
+  <div class="Panel-body">
+    <div class="Panel-row Panel-row--withCells">
+      <div class="Panel-cell">
+        <h4 class="Panel-title">
+          <a class="u-flex" href="sortColumn">
+            <span class="u-colorInfo u-textNoWrap">ID</span>
+            <div class="u-colorGrey u-fontSizeXs u-spaceLeftXs">
+              {{svg "up" class="Icon u-block u-colorHighlight" role="presentation"}}
+              {{svg "down" class="Icon u-block" role="presentation"}}
+            </div>
+          </a>
+        </h4>
+      </div>
+      <div class="Panel-cell">
+        <h4 class="Panel-title">
+          <a class="u-flex" href="sortColumn">
+            <span class="u-colorInfo u-textNoWrap">Status</span>
+            <div class="u-colorGrey u-fontSizeXs u-spaceLeftXs">
+              {{svg "up" class="Icon u-block" role="presentation"}}
+              {{svg "down" class="Icon u-block" role="presentation"}}
+            </div>
+          </a>
+        </h4>
+      </div>
+      <div class="Panel-cell">
+        <h4 class="Panel-title">
+          <a class="u-flex" href="sortColumn">
+            <span class="u-colorInfo u-textNoWrap">Date</span>
+            <div class="u-colorGrey u-fontSizeXs u-spaceLeftXs">
+              {{svg "up" class="Icon u-block" role="presentation"}}
+              {{svg "down" class="Icon u-block" role="presentation"}}
+            </div>
+          </a>
+        </h4>
+      </div>
+      <div class="Panel-cell">
+        <h4 class="Panel-title">
+          <a class="u-flex" href="sortColumn">
+            <span class="u-colorInfo u-textNoWrap">Type</span>
+            <div class="u-colorGrey u-fontSizeXs u-spaceLeftXs">
+              {{svg "up" class="Icon u-block" role="presentation"}}
+              {{svg "down" class="Icon u-block" role="presentation"}}
+            </div>
+          </a>
+        </h4>
+      </div>
+      <div class="Panel-cell">
+        <h4 class="Panel-title">
+          <a class="u-flex u-flexJustifyEnd u-spaceNegativeRightSm" href="sortColumn">
+            <span class="u-colorInfo u-textNoWrap">Total</span>
+            <div class="u-colorGrey u-fontSizeXs u-spaceLeftXs">
+              {{svg "up" class="Icon u-block" role="presentation"}}
+              {{svg "down" class="Icon u-block" role="presentation"}}
+            </div>
+          </a>
+        </h4>
+      </div>
+      <div class="Panel-cell">
+        <h4 class="Panel-title">
+          <a class="u-flex u-flexJustifyEnd u-spaceNegativeRightSm" href="sortColumn">
+            <span class="u-colorInfo u-textNoWrap">Payments</span>
+            <div class="u-colorGrey u-fontSizeXs u-spaceLeftXs">
+              {{svg "up" class="Icon u-block" role="presentation"}}
+              {{svg "down" class="Icon u-block" role="presentation"}}
+            </div>
+          </a>
+        </h4>
+      </div>
+      <div class="Panel-cell">
+        <h4 class="Panel-title">
+          <a class="u-flex u-flexJustifyEnd u-spaceNegativeRightSm" href="sortColumn">
+            <span class="u-colorInfo u-textNoWrap">Adjustments</span>
+            <div class="u-colorGrey u-fontSizeXs u-spaceLeftXs">
+              {{svg "up" class="Icon u-block" role="presentation"}}
+              {{svg "down" class="Icon u-block" role="presentation"}}
+            </div>
+          </a>
+        </h4>
+      </div>
+      <div class="Panel-cell">
+        <h4 class="Panel-title">
+          <a class="u-flex u-flexJustifyEnd u-spaceNegativeRightSm" href="sortColumn">
+            <span class="u-colorInfo u-textNoWrap">Balance</span>
+            <div class="u-colorGrey u-fontSizeXs u-spaceLeftXs">
+              {{svg "up" class="Icon u-block" role="presentation"}}
+              {{svg "down" class="Icon u-block" role="presentation"}}
+            </div>
+          </a>
+        </h4>
+      </div>
+      <div class="Panel-cell u-borderLeft u-spaceLeftSm">
+        <h4 class="Panel-title">
+          <a class="u-flex u-flexJustifyCenter" href="sortColumn">
+            <span class="u-colorInfo u-textNoWrap">Admin</span>
+          </a>
+        </h4>
+      </div>
+    </div>
+    <div style="height: 200px; overflow: scroll">
+      {{#each (data "invoicing.payments")}}
+        <div class="Panel-row Panel-row--withCells">
+          <div class="Panel-cell">
+            {{this.id}}
+          </div>
+          <div class="Panel-cell">
+            {{this.status}}
+          </div>
+          <div class="Panel-cell">
+            {{random "date" string=true}}
+          </div>
+          <div class="Panel-cell">
+            {{this.type}}
+          </div>
+          <div class="Panel-cell u-textRight">
+            ${{toFixed this.net}}
+          </div>
+          <div class="Panel-cell u-textRight">
+            {{random "dollar" max=1000}}
+          </div>
+          <div class="Panel-cell u-textRight">
+            {{random "dollar" max=1000}}
+          </div>
+          <div class="Panel-cell u-textRight">
+            {{#compare this.type "===" "offline" }}
+              ${{toFixed this.net}}
+            {{else}}
+              ${{toFixed (math this.net "*" 1.0299 "+" 0.99)}}
+            {{/compare}}
+          </div>
+          <div class="Panel-cell u-borderLeft u-textCenter u-spaceLeftSm">
+            <button class="Button Button--small Button--negative">
+                Refund
+            </button>
+          </div>
+        </div>
+      {{/each}}
+      {{#each (data "invoicing.payments")}}
+        <div class="Panel-row Panel-row--withCells">
+          <div class="Panel-cell">
+            {{this.id}}
+          </div>
+          <div class="Panel-cell">
+            {{this.status}}
+          </div>
+          <div class="Panel-cell">
+            {{random "date" string=true}}
+          </div>
+          <div class="Panel-cell">
+            {{this.type}}
+          </div>
+          <div class="Panel-cell u-textRight">
+            ${{toFixed this.net}}
+          </div>
+          <div class="Panel-cell u-textRight">
+            {{random "dollar" max=1000}}
+          </div>
+          <div class="Panel-cell u-textRight">
+            {{random "dollar" max=1000}}
+          </div>
+          <div class="Panel-cell u-textRight">
+            {{#compare this.type "===" "offline" }}
+              ${{toFixed this.net}}
+            {{else}}
+              ${{toFixed (math this.net "*" 1.0299 "+" 0.99)}}
+            {{/compare}}
+          </div>
+          <div class="Panel-cell u-borderLeft u-textCenter u-spaceLeftSm">
+            <button class="Button Button--small Button--negative">
+                Refund
+            </button>
+          </div>
+        </div>
+      {{/each}}
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
- Documents new `large` modifier styles for `Input` and `SelectBox`.
- Demonstrates option for table with fixed headers and vertically scrolling body.

<img width="933" alt="screen shot 2018-06-11 at 4 29 06 pm" src="https://user-images.githubusercontent.com/9888467/41258132-c4d3c5e2-6d94-11e8-80da-d0a6b094ad43.png">
<img width="932" alt="screen shot 2018-06-11 at 4 29 19 pm" src="https://user-images.githubusercontent.com/9888467/41258136-c75247f8-6d94-11e8-93df-766b0dd8df82.png">


![scrollable table](https://user-images.githubusercontent.com/9888467/41258137-cb75d34a-6d94-11e8-930e-486d3275fa69.gif)
