### PR TITLE
Add color utilities

### DIFF
--- a/src/data/themes.yaml
+++ b/src/data/themes.yaml
@@ -1,12 +1,3 @@
-- theme: blue-steel
-  name: Blue Steel
-
-- theme: care-bear
-  name: Care Bear
-
-- theme: christmas-sweater
-  name: Christmas Sweater
-
 - theme: custom-aquablue
   name: Aquablue
 
@@ -38,7 +29,7 @@
   name: Leaf Green
 
 - theme: custom-lemonyellow
-  name: Lemon Yellow
+  name: Yellow
 
 - theme: custom-lightblue
   name: Light Blue
@@ -58,14 +49,23 @@
 - theme: league
   name: League
 
-- theme: maple-leaf
-  name: Maple Leaf
+- theme: christmas-sweater
+  name: Christmas Sweater
 
-- theme: portland-oregon
-  name: Portland Oregon
+- theme: care-bear
+  name: Care Bear
 
 - theme: ranger-smith
   name: Ranger Smith
 
+- theme: blue-steel
+  name: Blue Steel
+
 - theme: up-beet
   name: Up Beet
+
+- theme: portland-oregon
+  name: Portland Oregon
+
+- theme: maple-leaf
+  name: Maple Leaf

--- a/src/pages/themes.hbs
+++ b/src/pages/themes.hbs
@@ -1,0 +1,49 @@
+---
+title: Themes
+notes: |
+  TeamSnap supports about two dozen different color themes. Users on Premium or Ultra plans can customize the web app UI with one of these themes.
+---
+
+<h1>{{title}}</h1>
+<p class='U-spaceBottomLg'>TeamSnap supports about two dozen different color themes. Users on Premium or Ultra plans can customize the web app UI with one of these themes.</p>
+
+<h3> Use the Theme Select in the menu to view theme colors:</h3>
+<div class="u-flex u-sizeFull">
+  <div class="u-bgPrimary u-padXl">
+    <p class="u-colorForeground">
+      Primary
+    </p>
+  </div>
+  <div class="u-bgSecondary u-padXl">
+    <p class="u-colorForeground">
+      Secondary
+    </p>
+  </div>
+  <div class="u-bgHighlight u-padXl">
+    <p class="u-colorForeground">
+      Highlight
+    </p>
+  </div>
+  <div class="u-padXl">
+    <p class="u-colorInfo">
+      Text Color
+      <a href="" class="u-padLeftMd">Link Color</a>
+    </p>
+  </div>
+</div>
+
+
+<h2 class="u-spaceTopXl">UI Examples</h2>
+<p>These are just a few examples. Click through Components in the menu to see how each responds to the different themes.</p>
+
+<div class="Panel u-spaceTopLg u-padLg">
+  <h2>Heading 2</h2>
+  <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque imperdiet mauris vitae enim sollicitudin mattis. Integer sapien ex, congue et dictum vitae, porta vitae felis. Suspendisse tortor odio, elementum id gravida non, malesuada vel nisl.</p>
+  <div class="u-spaceTopLg">
+    <button class="Button Button--negative u-spaceRightSm">Button Negative</button>
+    <button class="Button Button--primary">Button Primary</button>
+  </div>
+</div>
+
+{{> patterns.components.table.simple-table }}
+{{> patterns.components.feedback.color-modifiers }}

--- a/src/patterns/utilities/color/background-color.hbs
+++ b/src/patterns/utilities/color/background-color.hbs
@@ -1,0 +1,49 @@
+---
+order: 2
+notes: |
+  Applies themed background colors (except for positive and negative) to an element.
+sourceless: true
+---
+
+<div class="u-padXl u-bgPrimary">
+  <p class="u-colorForeground">
+    <strong>u-bgPrimary</strong>
+    <br>
+    (text color: u-colorForeground)
+  </p>
+</div>
+<div class="u-padXl u-bgSecondary">
+  <p class="u-colorForeground">
+    <strong>u-bgSecondary</strong>
+    <br>
+    (text color: u-colorForeground)
+  </p>
+</div>
+<div class="u-padXl u-bgHighlight">
+  <p class="u-colorForeground">
+    <strong>u-bgHighlight</strong>
+    <br>
+    (text color: u-colorForeground)
+  </p>
+</div>
+<div class="u-padXl u-bgLinkLight">
+  <a href="#" class="">
+    <strong>u-bgLinkLight</strong>
+    <br>
+    (text color - default link)
+  </a>
+</div>
+<div class="u-padXl u-bgPositive">
+  <p class="u-colorForeground">
+    <strong>u-bgPositive</strong>
+    <br>
+    (text color: u-colorForeground)
+  </p>
+</div>
+<div class="u-padXl u-bgNegative">
+  <p class="u-colorForeground">
+    <strong>u-bgNegative</strong>
+    <br>
+    (text color: u-colorForeground)
+  </p>
+</div>

--- a/src/patterns/utilities/color/link-color.hbs
+++ b/src/patterns/utilities/color/link-color.hbs
@@ -14,9 +14,18 @@ sourceless: true
 </div>
 
 <div class="u-spaceBottomLg">
-  <h3 class="u-colorInfo"><code>u-linkNegative</code></h3>
+  <h3 class="u-colorInfo">u-linkNegative</h3>
   <p>Styles links with red rather than the default link color.
   <p class="u-spaceTopSm">
     <a href="#" class="u-linkNegative">I am a link styled with u-linkNegative</a>
   </p>
+</div>
+
+<div class="u-spaceBottomLg">
+  <h3 class="u-colorInfo">u-linkCascade</h3>
+  <p>Applies link styles to all elements nested within anchor.
+  <a href="#" class="u-linkCascade">
+    <h2>Heading within anchor.</h2>
+    <p>Text within anchor.</p>
+  </a>
 </div>

--- a/src/patterns/utilities/color/link-color.hbs
+++ b/src/patterns/utilities/color/link-color.hbs
@@ -1,12 +1,22 @@
 ---
-order: 2
+order: 3
 notes: |
   Change the link color to something other than the default. You'll want this instead of plain ol' color utilities to set the interactive states.
+sourceless: true
 ---
 
-<p>
-  <a href="#">I am a normal link</a>
-</p>
-<p>
-  <a href="#" class="u-linkNegative">I am a link styled with u-linkNegative</a>
-</p>
+<div class="u-spaceBottomLg">
+  <h3 class="u-colorInfo">Normal links</h3>
+  <p>Links don't require a special class, and they will change with different color themes.</p>
+  <p class="u-spaceTopSm">
+    <a href="#">I am a normal link</a>
+  </p>
+</div>
+
+<div class="u-spaceBottomLg">
+  <h3 class="u-colorInfo"><code>u-linkNegative</code></h3>
+  <p>Styles links with red rather than the default link color.
+  <p class="u-spaceTopSm">
+    <a href="#" class="u-linkNegative">I am a link styled with u-linkNegative</a>
+  </p>
+</div>

--- a/src/patterns/utilities/color/text-color.hbs
+++ b/src/patterns/utilities/color/text-color.hbs
@@ -1,47 +1,66 @@
 ---
 order: 1
 notes: |
-  Applies `color` property for changing text color or icon color. These colors are themed and will vary depending on the color theme (except for positive and negative).
+  Applies color property for changing text color or icon color. These colors are themed and will vary depending on the color theme (except for positive and negative).
+sourceless: true
 ---
 <div class="u-padSm">
   <p class="u-colorPrimary">
     {{svg "check" class="Icon" role="presentation"}}
-    Color Primary
+    u-colorPrimary
   </p>
 </div>
 <div class="u-padSm">
   <p class="u-colorSecondary">
     {{svg "check" class="Icon" role="presentation"}}
-    Color Secondary
+    u-colorSecondary
   </p>
 </div>
 <div class="u-padSm">
   <p class="u-colorHighlight">
     {{svg "check" class="Icon" role="presentation"}}
-    Color Highlight
+    u-colorHighlight
   </p>
 </div>
 <div class="u-padSm">
   <p class="u-colorInfo">
     {{svg "check" class="Icon" role="presentation"}}
-    Color Info
+    u-colorInfo
   </p>
 </div>
 <div class="u-padSm">
   <p class="u-colorGrey">
     {{svg "check" class="Icon" role="presentation"}}
-    Color Grey
+    u-colorGrey
   </p>
 </div>
 <div class="u-padSm">
   <p class="u-colorPositive">
     {{svg "check" class="Icon" role="presentation"}}
-    Color Positive
+    u-colorPositive
   </p>
 </div>
 <div class="u-padSm">
   <p class="u-colorNegative">
     {{svg "check" class="Icon" role="presentation"}}
-    Color Negative
+    u-colorNegative
+  </p>
+</div>
+<div class="u-padSm u-bgPrimary">
+  <p class="u-colorForeground">
+    {{svg "check" class="Icon" role="presentation"}}
+    u-colorForeground on u-bgPrimary
+  </p>
+</div>
+<div class="u-padSm u-bgSecondary">
+  <p class="u-colorForeground">
+    {{svg "check" class="Icon" role="presentation"}}
+    u-colorForeground on u-bgSecondary
+  </p>
+</div>
+<div class="u-padSm u-bgHighlight">
+  <p class="u-colorForeground">
+    {{svg "check" class="Icon" role="presentation"}}
+    u-colorForeground on u-bgHighlight
   </p>
 </div>


### PR DESCRIPTION
- Adds documentation for new bg color utilities and improves layout of existing ones
- Adds new "themes" page to the intro section with some color swatches and UI examples to easily browse themes

![themes](https://user-images.githubusercontent.com/9888467/57550481-26e7ee00-732c-11e9-8a2e-629df40759fc.gif)

<img width="698" alt="Screen Shot 2019-05-10 at 1 27 01 PM" src="https://user-images.githubusercontent.com/9888467/57550383-d4a6cd00-732b-11e9-9f3f-8e98cf3df0c1.png">

<img width="384" alt="Screen Shot 2019-05-20 at 6 15 50 PM" src="https://user-images.githubusercontent.com/9888467/58105475-2eb95500-7bac-11e9-8502-c454c9eea43f.png">
