### PR TITLE
chore: remove dugout reference in favor of teamsnap-ui CDN

### DIFF
--- a/src/pages/index.hbs
+++ b/src/pages/index.hbs
@@ -46,7 +46,7 @@ order: 1
     For the fastest and simplest use, you can easily just drop in our CDN link to the &#60;head&#62; of your document.
     Themes are also accessible by referencing the themes directory and theme file at the end of the URL <code>/css/themes/league.css</code>.
   </p>
-  <pre class="language-markup u-padMd" data-bg="fill"><code>&#60;link rel="stylesheet" type="text/css" href="https://dugout.teamsnap.com/teamsnap-ui/2.15.1/css/teamsnap-ui.css"&#62;</code></pre>
+  <pre class="language-markup u-padMd" data-bg="fill"><code>&#60;link rel="stylesheet" type="text/css" href="https://teamsnap-ui.teamsnap.com/css/teamsnap-ui.css"&#62;</code></pre>
   <small><a href='https://github.com/teamsnap/teamsnap-ui/blob/master/CHANGELOG.md' target='_blank'>Find the the latest verison here</a></small>
   <h3 class="u-padTopLg">npm</h3>
   <p class="u-padTopSm u-padBottomSm">


### PR DESCRIPTION
We no longer want to support dugout with the advent of the `teamsnap-ui` CDN. This changeset fixes this.